### PR TITLE
zenscroll bug: switch to native scrolling

### DIFF
--- a/assets/scripts/entries-list.jsx
+++ b/assets/scripts/entries-list.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Spinner from 'react-spinner';
-import zenscroll from 'zenscroll';
 import ReactMarkdown from 'react-markdown';
 
 import firebase, { VOTES_DB } from './config.jsx';
@@ -42,15 +41,6 @@ export default class extends React.Component {
           return <li data-key={key} key={key} className={classes}>
             <div className='entry__header'>
               <a href={isActive ? '#none' : `#${key}`}
-                  onClick={() => {
-                    const currentElement = document.querySelector(
-                      `[data-key='${key}']`);
-                    if (currentElement) {
-                      setTimeout(() => {
-                        zenscroll.intoView(currentElement);
-                      }, 10);
-                    }
-                  }}
                   title={entry.title}
                   className='entry__header__title'>
                 <h3>

--- a/assets/scripts/main.jsx
+++ b/assets/scripts/main.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {render} from 'react-dom';
 import ReactFireMixin from 'reactfire';
-import zenscroll from 'zenscroll';
 
 import firebase, { VOTES_DB, INTERESTS_DB, CONTRIBUTIONS_DB } from './config.jsx';
 
@@ -70,15 +69,16 @@ const App = React.createClass({
       didRender = contributions.length + interests.length === entriesCount;
     let currentElement = null;
 
-    if (didRender && state.shallScroll && contributions.length &&
-        interests.length) {
-      this.setState({shallScroll: false});
+    if (didRender && state.shallScroll
+        && (contributions.length || interests.length)) {
 
       currentElement = document.querySelector(
         `[data-key='${currentEntryKey}']`);
 
       if (currentElement) {
-        zenscroll.to(currentElement);
+        this.setState({shallScroll: false}, () => {
+          currentElement.scrollIntoView();
+        });
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "to-markdown": "^3.0.3",
     "uglify-js": "^2.4.23",
     "watch-run": "^1.2.2",
-    "watchify": "^3.2.3",
-    "zenscroll": "^3.0.1"
+    "watchify": "^3.2.3"
   }
 }


### PR DESCRIPTION
due to a bug in zenscroll, scrolling
doesn't work in certain container DIVs

switching to native scrolling at least enables deep linking to contributions again.

There's a probably related issue in zen scroll but it's unresolved:
<https://github.com/zengabor/zenscroll/issues/30>